### PR TITLE
Add unit declarator to grammar declarations

### DIFF
--- a/lib/Chess/FEN.pm6
+++ b/lib/Chess/FEN.pm6
@@ -1,4 +1,4 @@
-grammar Chess::FEN;
+unit grammar Chess::FEN;
 
 rule TOP { <board> <active-color> <castling> <en-passant> <half-move-clock> <full-move-number> }
 

--- a/lib/Chess/PGN.pm6
+++ b/lib/Chess/PGN.pm6
@@ -1,4 +1,4 @@
-grammar Chess::PGN;
+unit grammar Chess::PGN;
 
 rule TOP { ^ <game>+? $ }
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
